### PR TITLE
Change "top left corner" to "top right corner" in note on landing page

### DIFF
--- a/intro.ipynb
+++ b/intro.ipynb
@@ -24,7 +24,7 @@
    },
    "source": [
     "```{margin} Map backgrounds\n",
-    "When zooming in on a specific station, consider switching to the satellite image background to see the actual site (top left corner).\n",
+    "When zooming in on a specific station, consider switching to the satellite image background to see the actual site (top right corner).\n",
     "```"
    ]
   },


### PR DESCRIPTION
The landing page suggests switching the basemap to satellite imagery using a toggle in the upper left corner, but that toggle is in the upper right corner:
![image](https://user-images.githubusercontent.com/57452607/137398445-3df05ecf-7f05-47d9-8d90-3ba801e0b4e1.png)
