### PR TITLE
Update google analytics ID

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,7 +31,7 @@ html:
   use_repository_button: true
   favicon: graphics/assessing_solar_favicon.ico  # A path to a favicon image
   baseurl                   : https://SolarStations.org
-  google_analytics_id       : UA-207152593-2
+  google_analytics_id       : G-6KXSD7FTJM
 
 # When to timeout each notebook in seconds
 execute:


### PR DESCRIPTION
Change the Google Analytics ID from the UA style which is being retired to the newer GA4.