### PR TITLE
Update solarstations.csv

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -81,7 +81,7 @@ Yushan Station,YUS,,Taiwan,23.4876,120.9595,3858,2018-,BSRN,,,,Freely,1,Thermopi
 Albuquerque,ABQ,New Mexico,USA,35.03796,-106.62211,1617,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/abq.html,Freely,1,Thermopile,G;B;D
 Bismarck,BIS,North Dakota,USA,46.77179,-100.75955,503,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/bis.html,Freely,1,Thermopile,G;B;D
 Hanford,HNX,California,USA,36.31357,-119.63164,73,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/hnx.html,Freely,1,Thermopile,G;B;D
-Madison,MSN,Wisconsin,USA,43.0725,-89.41133,271,1996-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/msn.html,Freely,1,Thermopile,G;B;D
+Madison,MSN,Wisconsin,USA,43.0725,-89.41133,271,1996-,SOLRAD,NOAA,Madison station file format changed after Jun 2009 (https://gml.noaa.gov/aftp/data/radiation/solrad/README_SOLRAD.txt),https://gml.noaa.gov/grad/solrad/msn.html,Freely,1,Thermopile,G;B;D
 Oak Ridge,ORT,Tennessee,USA,35.96101,-84.28838,334,1995-2007,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/ort.html,Freely,1,Thermopile,G;B;D
 Salt Lake City,SLC,Utah,USA,40.7722,-111.95495,1288,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/slc.html,Freely,1,Thermopile,G;B;D
 Seattle,SEA,Washington,USA,47.68685,-122.25667,20,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/sea.html,Freely,1,Thermopile,G;B;D

--- a/solarstations.csv
+++ b/solarstations.csv
@@ -78,14 +78,14 @@ Terra Nova Bay,TNB,,Antarctica,-74.6223,164.2283,28,,BSRN,,Candidate Station (no
 Toravere,TOR,,Estonia,58.254,26.462,70,1999-,BSRN,,,,Freely,1,Thermopile,G;B;D
 Xianghe,XIA,,China,39.754,116.962,32,2005-2016,BSRN,,Station obstructed& no longer in BSRN since 2016,,Freely,1,Thermopile,G;B;D
 Yushan Station,YUS,,Taiwan,23.4876,120.9595,3858,2018-,BSRN,,,,Freely,1,Thermopile,G;B;D
-Albuquerque,ABQ,New Mexico,USA,35.03796,-106.62211,1617,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/abq.html,Freely,1,Thermopile,G;B;D
-Bismarck,BIS,North Dakota,USA,46.77179,-100.75955,503,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/bis.html,Freely,1,Thermopile,G;B;D
-Hanford,HNX,California,USA,36.31357,-119.63164,73,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/hnx.html,Freely,1,Thermopile,G;B;D
-Madison,MSN,Wisconsin,USA,43.0725,-89.41133,271,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/msn.html,Freely,1,Thermopile,G;B;D
+Albuquerque,ABQ,New Mexico,USA,35.03796,-106.62211,1617,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/abq.html,Freely,1,Thermopile,G;B;D
+Bismarck,BIS,North Dakota,USA,46.77179,-100.75955,503,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/bis.html,Freely,1,Thermopile,G;B;D
+Hanford,HNX,California,USA,36.31357,-119.63164,73,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/hnx.html,Freely,1,Thermopile,G;B;D
+Madison,MSN,Wisconsin,USA,43.0725,-89.41133,271,1996-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/msn.html,Freely,1,Thermopile,G;B;D
 Oak Ridge,ORT,Tennessee,USA,35.96101,-84.28838,334,1995-2007,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/ort.html,Freely,1,Thermopile,G;B;D
-Salt Lake City,SLC,Utah,USA,40.7722,-111.95495,1288,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/slc.html,Freely,1,Thermopile,G;B;D
-Seattle,SEA,Washington,USA,47.68685,-122.25667,20,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/sea.html,Freely,1,Thermopile,G;B;D
-Sterling,STE,Virginia,USA,38.97203,-77.48690,85,,SOLRAD,NOAA,Site location pre Oct 28& 2014 (38.97673& -77.48379),https://gml.noaa.gov/grad/solrad/ste.html,Freely,1,Thermopile,G;B;D
+Salt Lake City,SLC,Utah,USA,40.7722,-111.95495,1288,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/slc.html,Freely,1,Thermopile,G;B;D
+Seattle,SEA,Washington,USA,47.68685,-122.25667,20,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/sea.html,Freely,1,Thermopile,G;B;D
+Sterling,STE,Virginia,USA,38.97203,-77.48690,85,1995-,SOLRAD,NOAA,Site location pre Oct 28& 2014 (38.97673& -77.48379),https://gml.noaa.gov/grad/solrad/ste.html,Freely,1,Thermopile,G;B;D
 Tallahassee,TLH,Florida,USA,30.39675,-84.32955,18,1995-2002,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/tlh.html,Freely,1,Thermopile,G;B;D
 Portland,PT,Oregon,USA,45.51,-122.69,70,2004-,SRML,University of Oregon,5-min data between 2004 and 2011.,http://solardat.uoregon.edu/PortlandPV.html,Freely,2,RSR,
 Burns,BU,Oregon,USA,43.52,-119.02,1265,1994-,SRML,University of Oregon,5 min data from 1994 to 2011.,http://solardat.uoregon.edu/Burns.html,Freely,1,Thermopile,

--- a/solarstations.csv
+++ b/solarstations.csv
@@ -82,11 +82,11 @@ Albuquerque,ABQ,New Mexico,USA,35.03796,-106.62211,1617,,SOLRAD,NOAA,,https://gm
 Bismarck,BIS,North Dakota,USA,46.77179,-100.75955,503,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/bis.html,Freely,1,Thermopile,G;B;D
 Hanford,HNX,California,USA,36.31357,-119.63164,73,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/hnx.html,Freely,1,Thermopile,G;B;D
 Madison,MSN,Wisconsin,USA,43.0725,-89.41133,271,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/msn.html,Freely,1,Thermopile,G;B;D
-Oak Ridge,ORT,Tennessee,USA,35.96101,-84.28838,334,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/ort.html,Freely,1,Thermopile,G;B;D
+Oak Ridge,ORT,Tennessee,USA,35.96101,-84.28838,334,1995-2007,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/ort.html,Freely,1,Thermopile,G;B;D
 Salt Lake City,SLC,Utah,USA,40.7722,-111.95495,1288,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/slc.html,Freely,1,Thermopile,G;B;D
 Seattle,SEA,Washington,USA,47.68685,-122.25667,20,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/sea.html,Freely,1,Thermopile,G;B;D
 Sterling,STE,Virginia,USA,38.97203,-77.48690,85,,SOLRAD,NOAA,Site location pre Oct 28& 2014 (38.97673& -77.48379),https://gml.noaa.gov/grad/solrad/ste.html,Freely,1,Thermopile,G;B;D
-Tallahassee,TLH,Florida,USA,30.39675,-84.32955,18,,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/tlh.html,Freely,1,Thermopile,G;B;D
+Tallahassee,TLH,Florida,USA,30.39675,-84.32955,18,1995-2002,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/tlh.html,Freely,1,Thermopile,G;B;D
 Portland,PT,Oregon,USA,45.51,-122.69,70,2004-,SRML,University of Oregon,5-min data between 2004 and 2011.,http://solardat.uoregon.edu/PortlandPV.html,Freely,2,RSR,
 Burns,BU,Oregon,USA,43.52,-119.02,1265,1994-,SRML,University of Oregon,5 min data from 1994 to 2011.,http://solardat.uoregon.edu/Burns.html,Freely,1,Thermopile,
 Silver lake,SL,Oregon,USA,43.12,-121.06,1355,2002-,SRML,University of Oregon,Only 5 minute data?,http://solardat.uoregon.edu/SilverLake.html,Freely,2,RSP,


### PR DESCRIPTION
Added time periods for SOLRAD TLH and ORT stations. Stations were shut down in 2002 and 2007, per https://gml.noaa.gov/grad/field.html.

Closes #57.