### PR TITLE
Fix issue with station markers not showing

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ jupyter-book
 matplotlib
 numpy
 pandas
-folium
+folium=0.12.1
 itables==1.1.2
 pvlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-jupyter-book
-matplotlib
-numpy
-pandas
+jupyter-book==0.13.0
+matplotlib==3.5.2
+numpy==1.23.1
+pandas==1.4.3
 folium==0.12.1
 itables==1.1.2
-pvlib
+pvlib==0.9.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ jupyter-book
 matplotlib
 numpy
 pandas
-folium=0.12.1
+folium==0.12.1
 itables==1.1.2
 pvlib


### PR DESCRIPTION
In the most recent build of the AssessingSolar.org website, the station markers are not shown correctly. This is most likely due to a change in one of the package dependencies. Thus, to solve this issue, the package dependencies should be fixed, i.e., the specific package version should be specified.

*Update: fixing folium==0.12.1 in the requirements.txt file solved the issue.*

Incorrect:
![image](https://user-images.githubusercontent.com/39184289/210815892-6d8e12ee-882d-4a64-bfcb-ccdf3bd925c1.png)

Correct:
![image](https://user-images.githubusercontent.com/39184289/210815995-f57d4142-a7e3-4e2f-a686-51d3aaf0e457.png)

