### PR TITLE
Update GH Actions workflow python version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR solves an issue introduced in #68. Specifically, in YAML files, you have to put a parenthesis around the python version if it has double digits. E.g., "3.10" would be correct, whereas specifying 3.10 would be read as 3.1...
