### PR TITLE
Add execution timeout (120 s)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,6 +9,7 @@ logo: graphics/assessing_solar_logo.png
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
+  timeout: 120
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
Currently, the PV-Live notebook is timing out due to the long processing time. To avoid this, the execution timeout is specified in the _config.yml file and set to 120 seconds.