### PR TITLE
Fix rendering of special characters in station listing table

### DIFF
--- a/docs/station_listing.ipynb
+++ b/docs/station_listing.ipynb
@@ -153,7 +153,7 @@
     "from itables import init_notebook_mode, show\n",
     "init_notebook_mode(all_interactive=True)\n",
     "\n",
-    "stations = pd.read_csv('../solarstations.csv', encoding='latin1').fillna('')\n",
+    "stations = pd.read_csv('../solarstations.csv').fillna('')\n",
     "\n",
     "# Format station as hyperlinks if URL is available\n",
     "for index, row in stations.iterrows():\n",


### PR DESCRIPTION
Closes #81.

The station listing notebook reads the CSV file using encoding `latin1`.  Not sure why that's the case.  `file` reports UTF-8:

```bash
$ file --mime-encoding solarstations.csv
solarstations.csv: utf-8
```

Removing the encoding argument (and thus using the default of `utf-8`) fixed the rendering of those characters in a local build.