### PR TITLE
Pin docutils to v0.17.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ itables==1.6.3
 pvlib==0.10.3
 unidecode==1.3.8
 kgcPy==1.1.3
+docutils==0.17.1  # https://github.com/executablebooks/jupyter-book/issues/1970


### PR DESCRIPTION
Closes #125.  See the warning here: https://jupyterbook.org/en/stable/content/citations.html

![image](https://github.com/AssessingSolar/solarstations/assets/57452607/be30424e-b2c7-4df8-b808-7c2a2e234aa0)
