### PR TITLE
Retire sauran network

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -98,26 +98,26 @@ DTU Climate Station,DTU,Capital region,Denmark,55.7906,12.5251,,2014-,None,Techn
 DTU Risø,RIS,Region Zealand,Denmark,55.6943,12.1017,,,None,Technical University of Denmark,Also has spectral measurements.,,Freely,1,Thermopile,
 University of KwaZulu-Natal Howard College,UKZN,Durban,South Africa,-29.87097931,30.97694969,150,2015-2021,SAURAN,,Roof of Desmond Clarence building. Permanently offline.,https://sauran.ac.za/station-documents/KZH/KZH%20Station%20Details.pdf,Freely,1,Thermopile,
 University of KwaZulu-Natal Westville,ZUL,Durban,South Africa,-29.81694031,30.94491959,200,2015-2020,SAURAN,,Roof of Physics building. Permanently offline.,,Freely,1,Thermopile,
-Stellenbosch University,STB,Stellenbosch,South Africa,-33.92810059,18.86540031,119,2010-,SAURAN,,Roof of Engineering building,https://sauran.ac.za,Freely,1,Thermopile,
-GIZ University of Pretoria,UOP,Pretoria,South Africa,-25.75308037,28.22859001,1410,2013-,SAURAN,,Roof of university building. Also has acronym UPR.,https://sauran.ac.za,Freely,,,
+Stellenbosch University,STB,Stellenbosch,South Africa,-33.92810059,18.86540031,119,2010-2024,SAURAN,,Roof of Engineering building,https://sauran.ac.za,Freely,1,Thermopile,
+GIZ University of Pretoria,UOP,Pretoria,South Africa,-25.75308037,28.22859001,1410,2013-2024,SAURAN,,Roof of university building. Also has acronym UPR.,https://sauran.ac.za,Freely,,,
 GIZ Vanrhynsdorp,RVLD,Vanrhynsdorp,South Africa,-31.61747932,18.73834038,130,2016-2019,SAURAN,,Inside enclosure on rural farmland. Permanently offline. Also goes by the acronym VAN.,https://sauran.ac.za/station-documents/VAN/VAN%20Station%20Details.pdf,Freely,,,
 GIZ University of Free State,UFS,Bloemfontein,South Africa,-29.11074066,26.18502998,1491,2014-2017,SAURAN,,Roof of Physics building. Permanently offline.,https://sauran.ac.za/station-documents/UFS/UFS%20Station%20Details.pdf,Freely,1,Thermopile,G;B;D
 GIZ Graaff-Reinet,GRN,Graaff-Reinet,South Africa,-32.48546982,24.58581924,660,2013-2016,SAURAN,,Inside enclosure on rural farmland. Permanently offline.,https://sauran.ac.za/station-documents/GRT/GRT%20Station%20Details.pdf,Freely,,,
 Nelson Mandela University,NMU,Port Elizabeth,South Africa,-34.0085907,25.66526031,35,2015-2021,SAURAN,,Roof of Solar Outdoor Research Facility. Permanently offline. Is this really correct? Check what data comes in?,https://sauran.ac.za/station-documents/NMU/NMU%20Station%20Details.pdf,Freely,1,Thermopile,G;B;D
-GIZ Richtersveld,RVLD,Alexander Bay,South Africa,-28.56084061,16.76145935,141,2014-,SAURAN,,Inside enclosure in desert region,https://sauran.ac.za/station-documents/RVD/RVD%20Station%20Details.pdf,Freely,1,Thermopile,G;B;D
+GIZ Richtersveld,RVLD,Alexander Bay,South Africa,-28.56084061,16.76145935,141,2014-2024,SAURAN,,Inside enclosure in desert region,https://sauran.ac.za/station-documents/RVD/RVD%20Station%20Details.pdf,Freely,1,Thermopile,G;B;D
 Mangosuthu University of Technology,MUT,Umlazi,South Africa,-29.97020912,30.91490936,95,2015-2021,SAURAN,,Roof of lecture complex. Diffuse with shadow band. Pyrheliometer on Eppley one-axis tracker. Permanently offline.,https://sauran.ac.za/station-documents/STA/STA%20Station%20Details.pdf,Freely,2,Thermopile.,G;B
 Eskom Sutherland,SALT,Sutherland,South Africa,-32.22199249,20.34777451,1450,2016-2017,SAURAN,,Permanently offline. Karoo scrubland.,https://sauran.ac.za/station-documents/SUT/SUT%20Station%20Details.pdf,Freely,1,Thermopile,G;B;D
 USAid Gaborone,GAB,Gaborone,Botswana,-24.6609993,25.93400002,1014,2014-2020,SAURAN,,Roof of building in University of Botswana,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
-USAid Venda,VEN,Vuwani,South Africa,-23.13100052,30.42399979,628,2015-,SAURAN,,Vuwani Science Research Centre,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
-University of Zululand,ZUL,KwaDlangezwa,South Africa,-28.85289955,31.85161018,90,2013-,SAURAN,,Roof of university building,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
-USAid Namibian University of Science and Technology,NUST,Windhoek,Namibia,-22.56500053,17.07500076,1683,2016-,SAURAN,,Roof of Engineering Building,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
-USAid University of Fort Hare,UFH,Alice,South Africa,-32.78461075,26.84519958,540,2017-,SAURAN,,Roof of Zoology Department,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
+USAid Venda,VEN,Vuwani,South Africa,-23.13100052,30.42399979,628,2015-2024,SAURAN,,Vuwani Science Research Centre,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
+University of Zululand,ZUL,KwaDlangezwa,South Africa,-28.85289955,31.85161018,90,2013-2024,SAURAN,,Roof of university building,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
+USAid Namibian University of Science and Technology,NUST,Windhoek,Namibia,-22.56500053,17.07500076,1683,2016-2024,SAURAN,,Roof of Engineering Building,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
+USAid University of Fort Hare,UFH,Alice,South Africa,-32.78461075,26.84519958,540,2017-2024,SAURAN,,Roof of Zoology Department,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
 GIZ Murraysburg,MRB,Murraysburg,South Africa,-31.89009094,24.05623055,1548,2017-2019,SAURAN,,Permanently offline. Inside enclosure on rural farmland.,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
 Mariendal,HELIO,Mariendal,South Africa,-33.85412979,18.82444954,178,2015-2020,SAURAN,,Permanently offline. Installed on a container.,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
 Eskom Sutherland SALT,,Sutherland,South Africa,-32.37778091,20.8116703,1761,2017-2020,SAURAN,,Permanently offline. Karoo scrubland.,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
-CSIR Energy Centre,CSIR,Pretoria,South Africa,-25.746519,28.278739,1400,2017-,SAURAN,,Roof of building,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
-Central University of Technology,CUT,Bloemfontein,South Africa,-29.121337,26.215909,1397,2017-,SAURAN,,Roof of the Engineering building,https://sauran.ac.za,Freely,1,Thermopile,G;B;D
-University of KwaZulu-Natal Pietermaritzburg,,Pietermaritzburg,South Africa,-29.621226,30.397038,680,2021-,SAURAN,,Rooftop,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
+CSIR Energy Centre,CSIR,Pretoria,South Africa,-25.746519,28.278739,1400,2017-2024,SAURAN,,Roof of building,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
+Central University of Technology,CUT,Bloemfontein,South Africa,-29.121337,26.215909,1397,2017-2024,SAURAN,,Roof of the Engineering building,https://sauran.ac.za,Freely,1,Thermopile,G;B;D
+University of KwaZulu-Natal Pietermaritzburg,,Pietermaritzburg,South Africa,-29.621226,30.397038,680,2021-2024,SAURAN,,Rooftop,https://sauran.ac.za/,Freely,1,Thermopile,G;B;D
 Anmyeondo GAW station,AMY,,South Korea,36.53,126.32,47,1999-,WMO GAW,,Also measured upwards shortwave and longwave irradiance and has a skyradiometer and a Brewer.,,,,,
 Jeju Gosan GAW station,JGS,,South Korea,33.3,126.21,52,2008-,WMO GAW,,The station also has a sky radiometer.,,,,,
 Weather Station De Veenkampen,,Wageningen,Netherlands,51.9812,5.6202,,2010-,None,Wageningen University,The quality of the radiation measurements are questionable.,https://ruisdael-observatory.nl/veenkampen/,,1,Thermopile,G;B;D


### PR DESCRIPTION
The SAURAN network website https://sauran.ac.za/ states that the SAURAN network is retired as of 2024:
> Please note that as of 2024, the SAURAN programme has reached its end-of-life. The historical data will still be available publicly here for the foreseeable future. The data has only been partially assessed so a full data quality assessment is required by anyone using the data. Please click [here](https://sauran.ac.za/SAURAN%20Information%20on%20Quality%20Assessments.zip) for more information on quality assessments.

