### PR TITLE
Update solarstations.csv

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -240,11 +240,11 @@ Hamm-Lippstadt University of Applied Science,HSHL,,Germany,51.682,7.843,60,2016-
 Alice Springs,,Northern Territory,Australia,-23.762361,133.875389,,2019-,,DKA Solar Centre,Parameters sampled at 1-second intervals and averaged at 5-second intervals,https://dkasolarcentre.com.au/locations/nt-solar-resource/alice-springs-2,Freely,2,Thermopile,G;B
 Tennant Creek,,Northern Territory,Australia,-19.679500, 134.261500,,2019-,,DKA Solar Centre,Parameters sampled at 1-second intervals and averaged at 5-second intervals,https://dkasolarcentre.com.au/locations/nt-solar-resource/tennant-creek,Freely,2,Thermopile,G;B
 Katherine,,Northern Territory,Australia,-14.474694, 132.305083,,2019-,,DKA Solar Centre,Parameters sampled at 1-second intervals and averaged at 5-second intervals,https://dkasolarcentre.com.au/locations/nt-solar-resource/katherine,Freely,2,Thermopile,G;B
-Artigas Airport,ARM,,Uruguay,-30.3984,-56.5117,136,2011-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,1,Thermopile,G;B;D
+Artigas Airport,ARM,,Uruguay,-30.3984,-56.5117,136,2011-2020,,Uruguay Solar Energy Laboratory,Experimental site with mixed use of instruments.,http://les.edu.uy/en/rmcis-en/,,2,,G;SPN1;
 Salto Grande,LES,,Uruguay,-31.2827,-57.9181,56,2015-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,1,Thermopile,G;B;D;UV;IR
-EE Palo a Pique,PPI,,Uruguay,-33.2581,-54.4804,26,2016-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,2,Thermopile,G;D
-Las Brujas,LBI,,Uruguay,-34.6720,-56.3401,38,2010-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,2,Thermopile,G;D
-EE La Magnolia,TAI,,Uruguay,-31.7090,-55.8269,142,2015-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,2,Thermopile,G;D
+EE Palo a Pique,PPI,,Uruguay,-33.2581,-54.4804,26,2016-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,2,,G;SPN1
+Las Brujas,LBI,,Uruguay,-34.6720,-56.3401,38,2010-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,2,,SPN1
+EE La Magnolia,TAI,,Uruguay,-31.7090,-55.8269,142,2015-,,Uruguay Solar Energy Laboratory,,http://les.edu.uy/en/rmcis-en/,,2,,SPN1
 Cuiabá,CBA,,Brazil,-15.5553,-56.0700,185,2006-2012,SONDA,INPE,No photos or instument info was provided,http://sonda.ccst.inpe.br/basedados/cuiaba.html,Freely,,,G;Ds
 Campo Grande,CGR,,Brazil,-20.4383,-54.5383,677,2004-2016,SONDA,INPE,Diffuse is measured with a shadowband,http://sonda.ccst.inpe.br/basedados/campogrande.html,Freely,2,Thermopile,G;Ds
 Palmas,PMA,,Brazil,-10.1778,-48.3619,216,2005-2016,SONDA,INPE,Diffuse is measured with a shadowband,http://sonda.ccst.inpe.br/basedados/palmas.html,Freely,2,Thermopile,G;Ds


### PR DESCRIPTION
The instrumentation at the stations in Uruguay was predominantly SPN1 instruments and not thermopile instruments. I noted this dispretancy because they had Instrumentation equal G;D which is unusual as D requires a tracker.