### PR TITLE
Reduce request timeout when checking URLs

### DIFF
--- a/.github/workflows/validate-csv.py
+++ b/.github/workflows/validate-csv.py
@@ -35,7 +35,7 @@ def check_url(row):
             return None  # URL is a special case; don't check it
 
     # use HEAD request for efficiency
-    response = requests.head(url, timeout=60)
+    response = requests.head(url, timeout=10)
     try:
         response.raise_for_status()
     except Exception as e:

--- a/.github/workflows/validate-csv.py
+++ b/.github/workflows/validate-csv.py
@@ -35,7 +35,7 @@ def check_url(row):
             return None  # URL is a special case; don't check it
 
     # use HEAD request for efficiency
-    response = requests.head(url, timeout=10)
+    response = requests.head(url, timeout=20)
     try:
         response.raise_for_status()
     except Exception as e:


### PR DESCRIPTION
Currently the URL checking workflow is slowing down the CI.

~~A website should be able to respond within 10 seconds, otherwise it will be considered failing.~~

_Edit: Many websites were failing when ``timeout=10``, even legimitate ones, so ``timeout`` has been increased to 20._