### PR TITLE
Replace , with ; in comments

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -25,7 +25,7 @@ Desert Rock,DRA,Nevada,USA,36.62373,-116.01947,1007,1994-,BSRN; SURFRAD,NOAA,,ht
 Darwin Met Office,DWN,Northern Territory,Australia,-12.424,130.8925,32,2008-,BSRN,,,,Freely,G;B;D
 Southern Great Plains,E13,Oklahoma,USA,36.60406,-97.48525,314,1994-,BSRN; ARM,,,http://www.arm.gov/sites/sgp,Freely,G;B;D
 Eastern North Atlantic,ENA,Azores,Portugal,39.0911,-28.0292,15.2,2015-,BSRN; ARM,,Ongoing issues with calibration.,https://www.arm.gov/capabilities/observatories/ena/locations/c1,Freely,G;B;D
-Eureka,EUR,Ellesmere Island,Canada,79.989,-85.9404,85,2007-2011,BSRN,,,"https://en.wikipedia.org/wiki/Eureka,_Nunavut",Freely,G;B;D
+Eureka,EUR,Ellesmere Island,Canada,79.989,-85.9404,85,2007-2011,BSRN,,,https://en.wikipedia.org/wiki/Eureka%2C_Nunavut,Freely,G;B;D
 Florianopolis,FLO;FLN,,Brazil,-27.6017,-48.5178,31,1994-2005&2013-,BSRN;SONDA,INPE,SONDA station (2004-2019). No maintenance between 2016-2017.,http://sonda.ccst.inpe.br/basedados/florianopolis.html,Freely,G;B;D;IR
 Fort Peck,FPE,Montana,USA,48.30783,-105.10170,634,1995-,BSRN;SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/ftpeck.html,Freely,G;B;D
 Fukuoka,FUA,,Japan,33.5822,130.3764,3,2010-,BSRN,,,https://epic.awi.de/id/eprint/36862/41/Fukuoka_old-and-new.pdf,Freely,G;B;D
@@ -86,7 +86,7 @@ Madison,MSN,Wisconsin,USA,43.0725,-89.41133,271,1996-,SOLRAD,NOAA,Madison statio
 Oak Ridge,ORT,Tennessee,USA,35.96101,-84.28838,334,1995-2007,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/ort.html,Freely,G;B;D
 Salt Lake City,SLC,Utah,USA,40.7722,-111.95495,1288,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/slc.html,Freely,G;B;D
 Seattle,SEA,Washington,USA,47.68685,-122.25667,20,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/sea.html,Freely,G;B;D
-Sterling,STE,Virginia,USA,38.97203,-77.48690,85,1995-,SOLRAD,NOAA,"Site location pre Oct 28 2014 (38.97673, -77.48379)",https://gml.noaa.gov/grad/solrad/ste.html,Freely,G;B;D
+Sterling,STE,Virginia,USA,38.97203,-77.48690,85,1995-,SOLRAD,NOAA,Site location pre Oct 28 2014 (lat:38.97673; lon:-77.48379).,https://gml.noaa.gov/grad/solrad/ste.html,Freely,G;B;D
 Tallahassee,TLH,Florida,USA,30.39675,-84.32955,18,1995-2002,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/tlh.html,Freely,G;B;D
 Portland,PT,Oregon,USA,45.51,-122.69,70,2004-,SRML,University of Oregon,5-min data between 2004 and 2011.,http://solardata.uoregon.edu/PortlandPV.html,Freely,RSR
 Burns,BU,Oregon,USA,43.52,-119.02,1265,1994-,SRML,University of Oregon,5 min data from 1994 to 2011.,http://solardata.uoregon.edu/Burns.html,Freely,G;B;D
@@ -122,9 +122,9 @@ University of KwaZulu-Natal Pietermaritzburg,,Pietermaritzburg,South Africa,-29.
 Anmyeondo GAW station,AMY,,South Korea,36.53,126.32,47,1999-,WMO GAW,,Also measured upwards shortwave and longwave irradiance and has a skyradiometer and a Brewer.,,,
 Jeju Gosan GAW station,JGS,,South Korea,33.3,126.21,52,2008-,WMO GAW,,The station also has a sky radiometer.,,,
 Weather Station De Veenkampen,,Wageningen,Netherlands,51.9812,5.6202,,2010-,,Wageningen University,The quality of the radiation measurements are questionable.,https://ruisdael-observatory.nl/veenkampen/,,G;B;D
-Kiruna,,,Sweden,67.842,20.41,424,1983-,SMHI,SMHI,,"https://www.smhi.se/data/meteorologi/ladda-ner-meteorologiska-observationer/#param=globalIrradians,stations=all",Upon request,G;B;D
-Norrköping,,,Sweden,58.582,16.148,43,1983-,SMHI;WMO RRC,SMHI,,"https://www.smhi.se/data/meteorologi/ladda-ner-meteorologiska-observationer/#param=globalIrradians,stations=all",Upon request,G;B;D
-Visby,,,Sweden,57.673,18.345,49,1983-,SMHI,SMHI,,"https://www.smhi.se/data/meteorologi/ladda-ner-meteorologiska-observationer/#param=globalIrradians,stations=all",Upon request,G;B;D
+Kiruna,,,Sweden,67.842,20.41,424,1983-,SMHI,SMHI,,https://www.smhi.se/data/hitta-data-for-en-plats/ladda-ner-vaderobservationer,Upon request,G;B;D
+Norrköping,,,Sweden,58.582,16.148,43,1983-,SMHI;WMO RRC,SMHI,,https://www.smhi.se/data/hitta-data-for-en-plats/ladda-ner-vaderobservationer,Upon request,G;B;D
+Visby,,,Sweden,57.673,18.345,49,1983-,SMHI,SMHI,,https://www.smhi.se/data/hitta-data-for-en-plats/ladda-ner-vaderobservationer,Upon request,G;B;D
 Luleå,,,Sweden,65.544,22.111,32,1983-2007,SMHI,SMHI,,https://www.smhi.se/polopoly_fs/1.166869!/Meteorologi_148%20Upgrade%20of%20SMHI%E2%80%99s%20meteorological%20radiation%20netwrok%202006-2007%20-%20Effects%20on%20direct%20and%20global%20solar%20radiation.pdf,Upon request,G;B
 Umeå,,,Sweden,63.811,20.240,23,1983-2008,SMHI,SMHI,,https://www.smhi.se/polopoly_fs/1.166869!/Meteorologi_148%20Upgrade%20of%20SMHI%E2%80%99s%20meteorological%20radiation%20netwrok%202006-2007%20-%20Effects%20on%20direct%20and%20global%20solar%20radiation.pdf,Upon request,G;B
 Östersund,,,Sweden,63.197,14.48,374,1983-2009,SMHI,SMHI,,https://www.smhi.se/polopoly_fs/1.166869!/Meteorologi_148%20Upgrade%20of%20SMHI%E2%80%99s%20meteorological%20radiation%20netwrok%202006-2007%20-%20Effects%20on%20direct%20and%20global%20solar%20radiation.pdf,Upon request,G;B
@@ -166,17 +166,17 @@ Mauna Loa,MLO,Hawaii,USA,19.5362,155.5763,3397,1976-,ABO,NOAA,Also downwelling l
 Cape Matatula,SMO,Tutila Island,American Samoa,14.2474,170.5644,42,1976-,ABO,NOAA,Diffuse irradiance measurements first started in 1995.,https://gml.noaa.gov/obop/smo/,Freely,G;B;D
 North Slope of Alaska,NSA,Alaska,USA,71.323,-156.609,8,1997-,ARM,,This site should note be confused with the NOAA Barrow site which is located ~1 km away. Radiation instruments are located at the Central Facility (Barrow),https://arm.gov/capabilities/observatories/nsa/locations/c1,Freely,G;B;D
 SRRL BMS,BMS,Colorado,USA,39.742,-105.18,1828.8,1981-,NREL MIDC,NREL,The NREL Solar Radiation Research Laboratory (SRRL) operates the largest collection of pyranometers and pyrheliometers in the world. Regular calibration and cleaning.,https://midcdmz.nrel.gov/apps/sitehome.pl?site=BMS,Freely,G;B;D
-SOLARTAC,STAC,Colorado,USA,39.75685,-104.62025,1674,2009-,NREL MIDC,,"Relatively good quality data, but somewhat inconsistent cleaning.",https://midcdmz.nrel.gov/apps/sitehome.pl?site=STAC,Freely,G;B;D
+SOLARTAC,STAC,Colorado,USA,39.75685,-104.62025,1674,2009-,NREL MIDC,,Relatively good quality data but somewhat inconsistent cleaning.,https://midcdmz.nrel.gov/apps/sitehome.pl?site=STAC,Freely,G;B;D
 Flatirons M2,NWTC,Colorado,USA,39.9106,-105.2347,1855,2021-,NREL MIDC,NREL,Regular calibration and cleaning as of 2022.,https://midcdmz.nrel.gov/apps/sitehome.pl?site=NWTC,Freely,G;B;D
-Casaccia Research Center,CAS,Lazio,Italy,42.04167,12.30667,,2001-,,ENEA,"Since 2020 also has PAR,albedo,UVA,UVB,spectral",,,G;B;D
+Casaccia Research Center,CAS,Lazio,Italy,42.04167,12.30667,,2001-,,ENEA,Since 2020 also has PAR; albedo; UVA; UVB; spectral.,,,G;B;D;UVA;UVB;PAR
 European Solar Test Installation - JRC,JRC,Ispra,Italy,45.81206,8.62706,220,1996-,,,,https://re.jrc.ec.europa.eu/meteo/meteo.php,Freely,G;B;D
 Ricerca sul Sistema Energetico,RSE,Milan,Italy,45.47488,9.26001,150,2012-,,RSE,Tracker is installed on the roof of a building (ground elevation is 108 m). The station also makes spectral measurement using a Spectrafy instrument.,,,G;B;D
 University of Girona,,Catalonia,Spain,41.96,2.83,110,1993-,,,,https://www.udg.edu/en/grupsrecerca/Fisica-Ambiental/Estacio-Meteorologica/Informacio-general-sobre-lestacio,,G;B;D
 Alamosa,SLV,Colorado,USA,37.70,-105.92,2317,2014-2016,SURFRAD,NOAA,,https://gml.noaa.gov/aftp/data/radiation/surfrad/,Freely,G;B;D
 Rutland,RUT,Vermont,USA,43.64,-72.97,184,2014-2015,SURFRAD,NOAA,,https://gml.noaa.gov/aftp/data/radiation/surfrad/,Freely,G;B;D
 Wasco,WAS,Oregon,USA,45.59,-120.67,200,2016-2017,SURFRAD,NOAA,,https://gml.noaa.gov/aftp/data/radiation/surfrad/,Freely,G;B;D
-Airai,,,Palau,7.368513,134.539830,47,2020-2022,PPA,,"Two GHI thermopile pyranometers (Hukseflux SR30-D1 and SR20-T2), a SPN-1, three reference cells, and a weather station.",https://energydata.info/dataset/palau-solar-radiation-measurement-data,Freely,G;SPN1
-Efate,,,Vanuatu,-17.709738,168.211453,152,2020-2022,PPA,,"The station is located on the UNELCO wind farm on Efate Island, Vanuatu.",https://energydata.info/dataset/vanuatu-solar-radiation-measurement-data,Freely,G;SPN1
+Airai,,,Palau,7.368513,134.539830,47,2020-2022,PPA,,Two GHI thermopile pyranometers (Hukseflux SR30-D1 and SR20-T2); a SPN-1; three reference cells; and a weather station.,https://energydata.info/dataset/palau-solar-radiation-measurement-data,Freely,G;SPN1
+Efate,,,Vanuatu,-17.709738,168.211453,152,2020-2022,PPA,,The station is located on the UNELCO wind farm on Efate Island innuatu.,https://energydata.info/dataset/vanuatu-solar-radiation-measurement-data,Freely,G;SPN1
 Nauru,,,Nauru,0.543447,166.931970,28,2020-2022,PPA,,,https://energydata.info/dataset/nauru-solar-radiation-measurement-data,Freely,G;SPN1
 Chuuk,,,Federated States of Micronesia,7.467517,151.849834,4,2020-2022,PPA,,,https://energydata.info/dataset/federates-states-of-micronesia-solar-radiation-measurement-data,Freely,G;SPN1
 Alotau,,,Papua New Guinea,-10.310113,150.337975,20,2020-2022,PPA,,,https://energydata.info/dataset/papua-new-guinea-solar-radiation-measurement-data,Freely,G;SPN1
@@ -189,9 +189,9 @@ Wien,,,Austria,48.25,16.36,198,2011-,ARAD,ZAMG,,https://www.zamg.ac.at/cms/de/kl
 Graz,,,Austria,47.08,15.45,398,2011-,ARAD,ZAMG,,https://www.zamg.ac.at/cms/de/klima/klimaforschung/datensaetze/arad,Upon request,G;B;D
 Innsbruck,,,Austria,47.26,11.38,578,2011-,ARAD,ZAMG,,https://www.zamg.ac.at/cms/de/klima/klimaforschung/datensaetze/arad,Upon request,G;B;D
 Kanzelhöhe,,,Austria,46.68,13.90,1540,2013-,ARAD,ZAMG,,https://www.zamg.ac.at/cms/de/klima/klimaforschung/datensaetze/arad,Upon request,G;B;D
-Davos,DAV,,Switzerland,46.8130,9.8440,1610,2000-,WMO RRC,MeteoSwiss,"GHI started in 1995, DNI in 2000, and diffuse in 2003.",https://www.meteoswiss.admin.ch/home/climate/swiss-climate-in-detail/radiation-monitoring.html,Upon request,G;B;D
+Davos,DAV,,Switzerland,46.8130,9.8440,1610,2000-,WMO RRC,MeteoSwiss,GHI started in 1995; DNI in 2000; and diffuse in 2003.,https://www.meteoswiss.admin.ch/home/climate/swiss-climate-in-detail/radiation-monitoring.html,Upon request,G;B;D
 Jungfraujoch,JUN,,Switzerland,46.5500,7.9900,3582,1996-,,MeteoSwiss,No diffuse measurements due to too hars meteorological conditions.,https://www.meteoswiss.admin.ch/home/climate/swiss-climate-in-detail/radiation-monitoring.html,Upon request,G;B;D
-Locarno-Monti,OTL,,Switzerland,46.1800,8.7830,366,2000-,,MeteoSwiss,"GHI from 1996, DNI from 2000, and diffuse from 2001.",https://www.meteoswiss.admin.ch/home/climate/swiss-climate-in-detail/radiation-monitoring.html,Upon request,G;B;D
+Locarno-Monti,OTL,,Switzerland,46.1800,8.7830,366,2000-,,MeteoSwiss,GHI from 1996; DNI from 2000; and diffuse from 2001.,https://www.meteoswiss.admin.ch/home/climate/swiss-climate-in-detail/radiation-monitoring.html,Upon request,G;B;D
 Amitie,amitie,,Seychelles,-4.321022,55.693361,3,2019-,IOS-net,,Data can be downloaded from: https://doi.org/10.5281/zenodo.4408667,https://galilee.univ-reunion.fr/,Freely,SPN1;UV
 Anse Boileau,anseboileau,,Seychelles,-4.710958,55.484732,2,2019-,IOS-net,,Data can be downloaded from: https://doi.org/10.5281/zenodo.4408665,https://galilee.univ-reunion.fr/,Freely,SPN1;UV
 Antananarivo,antananarivo,,Madagascar,-18.89833,47.546422,1309,2019-,IOS-net,,Data can be downloaded from: https://doi.org/10.5281/zenodo.4408673,https://galilee.univ-reunion.fr/,Freely,SPN1;UV
@@ -278,7 +278,7 @@ Tabouk,,,Saudi Arabia,28.38,36.61,768,1998-2003,,NREL;KACST,,https://www.nrel.go
 Wadi Al-Dawaser,,,Saudi Arabia,20.44,44.68,701,1998-2003,,NREL;KACST,,https://www.nrel.gov/grid/solar-resource/saudi-arabia.html,Freely,G;B;D
 Evora;Mitra,,,Portugal,38.531,-8.011,220,2014-,,University of Évora,,,,G;B;D
 Badajoz,,,Spain,38.886028,-7.009250,190,2008-,,University of Extremadura,,,,G;B;D
-Varennes,,Quebec,Canada,45.62650,-73.38203,22,1995-,,Natural Resources Canada,"Complete station upgrade in 2017. Prior to 2017, station was rather unreliable and maintenance was less rigorous. Spectral radiation measurements using Spectrafy sensors also available.",,Upon request,G;B;D
+Varennes,,Quebec,Canada,45.62650,-73.38203,22,1995-,,Natural Resources Canada,Complete station upgrade in 2017. Prior to 2017 station was rather unreliable and maintenance was less rigorous. Spectral radiation measurements using Spectrafy sensors are also available.,,Upon request,G;B;D
 Shagaya,,,Kuwait,29.2099,47.0603,241,2012-?,,KISR,,,,G;B;D;RSI
 Kabed,,,Kuwait,29.173152,47.728054,76,2012-?,,KISR,,,,G;B;D;RSI
 Mutribah,,,Kuwait,29.90,47.28,,2012-?,,KISR,Location is approximate,,,G;RSI


### PR DESCRIPTION
This PR replaces all commas (,) in the comments section with semicolon (;) to make the station catalog easier to use. This also gets rid of all double quotes (") which were used to encapsulate the commas in the comment column.

This is based on a reviewer comment from the paper submitted to Solar Energy:

> As a detail, the authors mention in section 4 (Implementation) that the metadata is stored as a comma-separated values (CSV) file. However, the comment column includes some double-quoted comments that include commas, which in my case posed a few problems until I specifically instructed my reading software not to consider commas in double-quoted strings. It should not be mentioned in the manuscript, but could be mentioned in the station catalog section of the web site.