### PR TITLE
Add IR to all BSRN station instrumentations

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -1,84 +1,84 @@
 Station name,Abbreviation,State,Country,Latitude,Longitude,Elevation,Time period,Network,Owner,Comment,URL,Data availability,Instrumentation
-Abashiri,ABS,,Japan,44.0178,144.2797,38,2021-,BSRN,,,,Freely,G;B;D
-Alert,ALE,Lincoln Sea,Canada,82.49,-62.42,127,2004-2014,BSRN,,,,Freely,G;B;D
+Abashiri,ABS,,Japan,44.0178,144.2797,38,2021-,BSRN,,,,Freely,G;B;D;IR
+Alert,ALE,Lincoln Sea,Canada,82.49,-62.42,127,2004-2014,BSRN,,,,Freely,G;B;D;IR
 Alice Springs,ASP,Northern Territory,Australia,-23.7951,133.8890,546,1995-,BSRN,BOM,,http://www.bom.gov.au/climate/data/oneminsolar/about-IDCJAC0022.shtml,Freely,G;B;D;IR
-Barrow,BAR,Alaska,USA,71.323,-156.607,8,1992-,BSRN; ABO,NOAA,,https://gml.noaa.gov/obop/brw/,Freely,G;B;D
-Bermuda,BER,Bermuda,USA,32.267,-64.667,8,1992-2013&2016-,BSRN,,,,Freely,G;B;D
-Billings,BIL,Oklahoma,USA,36.605,-97.516,317,1993-,BSRN,,,,Freely,G;B;D
-Bondville,BON,Illinois,USA,40.05192,-88.37309,230,1995-,BSRN; SURFRAD,NOAA,,http://www.srrb.noaa.gov/surfrad/bondvill.html,Freely,G;B;D
-Boulder,BOS,Colorado,USA,40.12498,-105.23680,1689,1995-,BSRN; SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/tablemt.html,Freely,G;B;D
-Boulder,BOU,Colorado,USA,40.05,-105.007,1577,1992-2016,BSRN,,,,Freely,G;B;D
+Barrow,BAR,Alaska,USA,71.323,-156.607,8,1992-,BSRN; ABO,NOAA,,https://gml.noaa.gov/obop/brw/,Freely,G;B;D;IR
+Bermuda,BER,Bermuda,USA,32.267,-64.667,8,1992-2013&2016-,BSRN,,,,Freely,G;B;D;IR
+Billings,BIL,Oklahoma,USA,36.605,-97.516,317,1993-,BSRN,,,,Freely,G;B;D;IR
+Bondville,BON,Illinois,USA,40.05192,-88.37309,230,1995-,BSRN; SURFRAD,NOAA,,http://www.srrb.noaa.gov/surfrad/bondvill.html,Freely,G;B;D;IR
+Boulder,BOS,Colorado,USA,40.12498,-105.23680,1689,1995-,BSRN; SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/tablemt.html,Freely,G;B;D;IR
+Boulder,BOU,Colorado,USA,40.05,-105.007,1577,1992-2016,BSRN,,,,Freely,G;B;D;IR
 Brasilia,BRB,,Brazil,-15.601259,-47.713774,1023,2006-2015&2018-,BSRN;SONDA,INPE,SONDA station (2004-2019). No maintenance between 2016-2017.,http://sonda.ccst.inpe.br/basedados/brasilia.html,Freely,G;B;D;IR
-Budapest-Lorinc,BUD,Budapest,Hungary,47.4291,19.1822,139.1,2019-,BSRN;WMO RRC,,,,Freely,G;B;D
-Cabauw,CAB,,Netherlands,51.9711,4.9267,0,2005-,BSRN,,,https://dataplatform.knmi.nl/dataset/cesar-bsrn-irraddown-la1-t1-v1-0,Freely,G;B;D
-Camborne,CAM,,United Kingdom,50.2167,-5.3167,88,2001-,BSRN,,,https://epic.awi.de/id/eprint/40425/1/Camborne_BSRN_Station_Info.pdf,Freely,G;B;D
-Cape Baranova,CAP,,Russia,79.27,101.75,,2016-,BSRN,,,,Freely,G;B;D
-Carpentras,CAR,,France,44.083,5.059,100,1996-2018,BSRN;WMO RRC,,,,Freely,G;B;D
-Chesapeake Light,CLH,North Atlantic Ocean,USA,36.905,-75.713,37,2000-2016,BSRN,NASA,Closed due to structural issues,https://science.larc.nasa.gov/crave/,Freely,G;B;D
-Cener,CNR,Navarra,Spain,42.816,-1.601,471,2009-,BSRN,,,,Freely,G;B;D
-Cocos Island,COC,Cocos (Keeling) Islands,Australia,-12.1892,96.8344,3,2004-,BSRN,BOM,,http://www.bom.gov.au/climate/data/oneminsolar/about-IDCJAC0022.shtml,Freely,G;B;D
-De Aar,DAA,,South Africa,-30.6667,23.993,1287,2000-,BSRN,,,,Freely,G;B;D
+Budapest-Lorinc,BUD,Budapest,Hungary,47.4291,19.1822,139.1,2019-,BSRN;WMO RRC,,,,Freely,G;B;D;IR
+Cabauw,CAB,,Netherlands,51.9711,4.9267,0,2005-,BSRN,,,https://dataplatform.knmi.nl/dataset/cesar-bsrn-irraddown-la1-t1-v1-0,Freely,G;B;D;IR
+Camborne,CAM,,United Kingdom,50.2167,-5.3167,88,2001-,BSRN,,,https://epic.awi.de/id/eprint/40425/1/Camborne_BSRN_Station_Info.pdf,Freely,G;B;D;IR
+Cape Baranova,CAP,,Russia,79.27,101.75,,2016-,BSRN,,,,Freely,G;B;D;IR
+Carpentras,CAR,,France,44.083,5.059,100,1996-2018,BSRN;WMO RRC,,,,Freely,G;B;D;IR
+Chesapeake Light,CLH,North Atlantic Ocean,USA,36.905,-75.713,37,2000-2016,BSRN,NASA,Closed due to structural issues,https://science.larc.nasa.gov/crave/,Freely,G;B;D;IR
+Cener,CNR,Navarra,Spain,42.816,-1.601,471,2009-,BSRN,,,,Freely,G;B;D;IR
+Cocos Island,COC,Cocos (Keeling) Islands,Australia,-12.1892,96.8344,3,2004-,BSRN,BOM,,http://www.bom.gov.au/climate/data/oneminsolar/about-IDCJAC0022.shtml,Freely,G;B;D;IR
+De Aar,DAA,,South Africa,-30.6667,23.993,1287,2000-,BSRN,,,,Freely,G;B;D;IR
 Darwin,DAR,Northern Territory,Australia,-12.4239,130.8925,30.4,2002-2021,BSRN,BOM,BSRN data available until 2015,http://www.bom.gov.au/climate/data/oneminsolar/about-IDCJAC0022.shtml,Freely,G;B;D;IR
-Concordia Station & Dome C,DOM,,Antarctica,-75.1,123.383,3233,2006-,BSRN,,,,Freely,G;B;D
+Concordia Station & Dome C,DOM,,Antarctica,-75.1,123.383,3233,2006-,BSRN,,,,Freely,G;B;D;IR
 Dongsha Atoll,DON,,Taiwan,20.7,116.73,2,?,,National Central University Taiwan,Previously a BSRN provisional station.,https://gml.noaa.gov/dv/site/index.php?stacode=DSI,Freely,G;B;D
-Desert Rock,DRA,Nevada,USA,36.62373,-116.01947,1007,1994-,BSRN; SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/desrock.html,Freely,G;B;D
-Darwin Met Office,DWN,Northern Territory,Australia,-12.424,130.8925,32,2008-,BSRN,,,,Freely,G;B;D
-Southern Great Plains,E13,Oklahoma,USA,36.60406,-97.48525,314,1994-,BSRN; ARM,,,http://www.arm.gov/sites/sgp,Freely,G;B;D
-Eastern North Atlantic,ENA,Azores,Portugal,39.0911,-28.0292,15.2,2015-,BSRN; ARM,,Ongoing issues with calibration.,https://www.arm.gov/capabilities/observatories/ena/locations/c1,Freely,G;B;D
-Eureka,EUR,Ellesmere Island,Canada,79.989,-85.9404,85,2007-2011,BSRN,,,https://en.wikipedia.org/wiki/Eureka%2C_Nunavut,Freely,G;B;D
+Desert Rock,DRA,Nevada,USA,36.62373,-116.01947,1007,1994-,BSRN; SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/desrock.html,Freely,G;B;D;IR
+Darwin Met Office,DWN,Northern Territory,Australia,-12.424,130.8925,32,2008-,BSRN,,,,Freely,G;B;D;IR
+Southern Great Plains,E13,Oklahoma,USA,36.60406,-97.48525,314,1994-,BSRN; ARM,,,http://www.arm.gov/sites/sgp,Freely,G;B;D;IR
+Eastern North Atlantic,ENA,Azores,Portugal,39.0911,-28.0292,15.2,2015-,BSRN; ARM,,Ongoing issues with calibration.,https://www.arm.gov/capabilities/observatories/ena/locations/c1,Freely,G;B;D;IR
+Eureka,EUR,Ellesmere Island,Canada,79.989,-85.9404,85,2007-2011,BSRN,,,https://en.wikipedia.org/wiki/Eureka%2C_Nunavut,Freely,G;B;D;IR
 Florianopolis,FLO;FLN,,Brazil,-27.6017,-48.5178,31,1994-2005&2013-,BSRN;SONDA,INPE,SONDA station (2004-2019). No maintenance between 2016-2017.,http://sonda.ccst.inpe.br/basedados/florianopolis.html,Freely,G;B;D;IR
-Fort Peck,FPE,Montana,USA,48.30783,-105.10170,634,1995-,BSRN;SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/ftpeck.html,Freely,G;B;D
-Fukuoka,FUA,,Japan,33.5822,130.3764,3,2010-,BSRN,,,https://epic.awi.de/id/eprint/36862/41/Fukuoka_old-and-new.pdf,Freely,G;B;D
-Gandhinagar,GAN,,India,23.1101,72.6276,65,2014-2015&2018-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D
-Goodwin Creek,GCR,Mississippi,USA,34.2547,-89.8729,98,1995-,BSRN;SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/goodwin.html,Freely,G;B;D
-Granite Island,GIM,Michigan,USA,46.721,-87.411,208,2019-,BSRN,NASA,,https://science.larc.nasa.gov/crave/,Freely,G;B;D
-Gobabeb,GOB,Namib Desert,Namibia,-23.5614,15.042,407,2012-,BSRN,,,,Freely,G;B;D
-Gurgaon,GUR,,India,28.4249,77.156,259,2014-2015&2018-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D
-Georg von Neumayer,GVN,Dronning Maud Island,Antarctica,-70.65,-8.25,42,1982-,BSRN,,Neumayer-station II from 1992-2009 & Neumayer station III from 2009. BSRN FTP server only has data from 1992.,https://www.awi.de/en/science/long-term-observations/atmosphere/antarctic-neumayer.html,Freely,G;B;D
-Howrah,HOW,,India,22.5535,88.3064,51,2014-2016&2018-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D
-Ilorin,ILO,,Nigeria,8.5333,4.5667,350,1992-2005,BSRN,,Station closed due to no funding,,Freely,G;B;D
-Ishigakijima,ISH,,Japan,24.3367,124.1644,5.7,2010-,BSRN,,,,Freely,G;B;D
-Izaña,IZA,Tenerife,Spain,28.3093,-16.4993,2372.9,2009-,BSRN,,,,Freely,G;B;D
-Kwajalein,KWA,,Marshall Islands,8.72,167.731,10,1992-2017,BSRN,,,https://gml.noaa.gov/grad/sites/kwa.html,Freely,G;B;D
-Lampedusa,LMP,,Italy,35.5180,12.6300,50.0,2023-,BSRN,,,,Freely,G;B;D
-Lauder,LAU,,New Zealand,-45.045,169.689,350,1999-,BSRN,,,,Freely,G;B;D
-Lerwick,LER,Shetland Island,United Kingdom,60.1389,-1.1847,80,2001-,BSRN,,,https://epic.awi.de/id/eprint/35071/1/Lerwick_site_info.pdf,Freely,G;B;D
-Lindenberg,LIN,,Germany,52.21,14.122,125,1994-,BSRN;WMO RRC,,,https://www.dwd.de/DE/forschung/atmosphaerenbeob/lindenbergersaeule/mol/mol_node.html,Freely,G;B;D
+Fort Peck,FPE,Montana,USA,48.30783,-105.10170,634,1995-,BSRN;SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/ftpeck.html,Freely,G;B;D;IR
+Fukuoka,FUA,,Japan,33.5822,130.3764,3,2010-,BSRN,,,https://epic.awi.de/id/eprint/36862/41/Fukuoka_old-and-new.pdf,Freely,G;B;D;IR
+Gandhinagar,GAN,,India,23.1101,72.6276,65,2014-2015&2018-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D;IR
+Goodwin Creek,GCR,Mississippi,USA,34.2547,-89.8729,98,1995-,BSRN;SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/goodwin.html,Freely,G;B;D;IR
+Granite Island,GIM,Michigan,USA,46.721,-87.411,208,2019-,BSRN,NASA,,https://science.larc.nasa.gov/crave/,Freely,G;B;D;IR
+Gobabeb,GOB,Namib Desert,Namibia,-23.5614,15.042,407,2012-,BSRN,,,,Freely,G;B;D;IR
+Gurgaon,GUR,,India,28.4249,77.156,259,2014-2015&2018-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D;IR
+Georg von Neumayer,GVN,Dronning Maud Island,Antarctica,-70.65,-8.25,42,1982-,BSRN,,Neumayer-station II from 1992-2009 & Neumayer station III from 2009. BSRN FTP server only has data from 1992.,https://www.awi.de/en/science/long-term-observations/atmosphere/antarctic-neumayer.html,Freely,G;B;D;IR
+Howrah,HOW,,India,22.5535,88.3064,51,2014-2016&2018-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D;IR
+Ilorin,ILO,,Nigeria,8.5333,4.5667,350,1992-2005,BSRN,,Station closed due to no funding,,Freely,G;B;D;IR
+Ishigakijima,ISH,,Japan,24.3367,124.1644,5.7,2010-,BSRN,,,,Freely,G;B;D;IR
+Izaña,IZA,Tenerife,Spain,28.3093,-16.4993,2372.9,2009-,BSRN,,,,Freely,G;B;D;IR
+Kwajalein,KWA,,Marshall Islands,8.72,167.731,10,1992-2017,BSRN,,,https://gml.noaa.gov/grad/sites/kwa.html,Freely,G;B;D;IR
+Lampedusa,LMP,,Italy,35.5180,12.6300,50.0,2023-,BSRN,,,,Freely,G;B;D;IR
+Lauder,LAU,,New Zealand,-45.045,169.689,350,1999-,BSRN,,,,Freely,G;B;D;IR
+Lerwick,LER,Shetland Island,United Kingdom,60.1389,-1.1847,80,2001-,BSRN,,,https://epic.awi.de/id/eprint/35071/1/Lerwick_site_info.pdf,Freely,G;B;D;IR
+Lindenberg,LIN,,Germany,52.21,14.122,125,1994-,BSRN;WMO RRC,,,https://www.dwd.de/DE/forschung/atmosphaerenbeob/lindenbergersaeule/mol/mol_node.html,Freely,G;B;D;IR
 Lulin,LLN,,Taiwan,23.4686,120.8736,2862,2009-,,,Previously a BSRN provisional stations.,http://lulin.tw/,Freely,G;B;D
-Langley Research Center,LRC,Virginia,USA,37.1038,-76.3872,3,2014-,BSRN,NASA,,https://science.larc.nasa.gov/crave/,Freely,G;B;D
-Lanyu Station,LYU,,Taiwan,22.037,121.5583,324,2018-,BSRN,,,,Freely,G;B;D
-Momote,MAN,,Papua New Guinea,-2.058,147.425,6,1996-2013,BSRN,,,,Freely,G;B;D
-Minamitorishima,MNM,Minami-Torishima,Japan,24.2883,153.9833,7.1,2010-,BSRN,,,https://epic.awi.de/id/eprint/36862/3/Minamitorishima.pdf,Freely,G;B;D
-Marguele,MRS,,Romania,44.3439,26.0123,110,?,BSRN,,Candidate Station (no. 88),,Freely,G;B;D
-Nauru Island,NAU,,Nauru,-0.521,166.9167,7,1998-2013,BSRN,,,,Freely,G;B;D
-Newcastle,NEW,New South Wales,Australia,-32.8842,151.7289,18.5,2017-,BSRN,,,,Freely,G;B;D
-Ny-Ålesund,NYA,Spitsberger,Norway,78.925,11.93,11,1992-,BSRN,,,https://www.awi.de/en/fleet-stations/stations/awipev-arctic-research-base.html,Freely,G;B;D
-Observatory of Huancayo,OHY,,Peru,-12.05,-75.32,3314,2017-,BSRN,,,,Freely,G;B;D
-Palaiseau & SIRTA Observatory,PAL,,France,48.713,2.208,156,2003-,BSRN,,,,Freely,G;B;D
-Paramaribo,PAR,,Suriname,5.806,-55.2146,4,2019-,BSRN,,,,Freely,G;B;D
-Payerne,PAY,,Switzerland,46.8123,6.9422,491,1992-,BSRN,MeteoSwiss,,,Freely,G;B;D
-Rock Springs,PSU,Pennsylvania,USA,40.72012,-77.93085,376,1998-,BSRN;SURFRAD,NOAA,SURFRAD station known as Penn State,https://gml.noaa.gov/grad/surfrad/pennstat.html,Freely,G;B;D
+Langley Research Center,LRC,Virginia,USA,37.1038,-76.3872,3,2014-,BSRN,NASA,,https://science.larc.nasa.gov/crave/,Freely,G;B;D;IR
+Lanyu Station,LYU,,Taiwan,22.037,121.5583,324,2018-,BSRN,,,,Freely,G;B;D;IR
+Momote,MAN,,Papua New Guinea,-2.058,147.425,6,1996-2013,BSRN,,,,Freely,G;B;D;IR
+Minamitorishima,MNM,Minami-Torishima,Japan,24.2883,153.9833,7.1,2010-,BSRN,,,https://epic.awi.de/id/eprint/36862/3/Minamitorishima.pdf,Freely,G;B;D;IR
+Marguele,MRS,,Romania,44.3439,26.0123,110,?,BSRN,,Candidate Station (no. 88),,Freely,G;B;D;IR
+Nauru Island,NAU,,Nauru,-0.521,166.9167,7,1998-2013,BSRN,,,,Freely,G;B;D;IR
+Newcastle,NEW,New South Wales,Australia,-32.8842,151.7289,18.5,2017-,BSRN,,,,Freely,G;B;D;IR
+Ny-Ålesund,NYA,Spitsberger,Norway,78.925,11.93,11,1992-,BSRN,,,https://www.awi.de/en/fleet-stations/stations/awipev-arctic-research-base.html,Freely,G;B;D;IR
+Observatory of Huancayo,OHY,,Peru,-12.05,-75.32,3314,2017-,BSRN,,,,Freely,G;B;D;IR
+Palaiseau & SIRTA Observatory,PAL,,France,48.713,2.208,156,2003-,BSRN,,,,Freely,G;B;D;IR
+Paramaribo,PAR,,Suriname,5.806,-55.2146,4,2019-,BSRN,,,,Freely,G;B;D;IR
+Payerne,PAY,,Switzerland,46.8123,6.9422,491,1992-,BSRN,MeteoSwiss,,,Freely,G;B;D;IR
+Rock Springs,PSU,Pennsylvania,USA,40.72012,-77.93085,376,1998-,BSRN;SURFRAD,NOAA,SURFRAD station known as Penn State,https://gml.noaa.gov/grad/surfrad/pennstat.html,Freely,G;B;D;IR
 Petrolina,PTR,,Brazil,-9.068,-40.319,387,2006-,BSRN;SONDA,INPE,SONDA station (2004-2019). No maintenance between 2016-2017.,http://sonda.ccst.inpe.br/basedados/petrolina.html,Freely,G;B;D;IR
-Regina,REG,,Canada,50.205,-104.713,578,1995-2011,BSRN,,,,Freely,G;B;D
-Rolim de Moura,RLM,,Brazil,-11.582,-61.773,252,2007,BSRN,,Only two months of data available.,,Freely,G;B;D
-Reunion Island & University,RUN,,Reunion,-20.9014,55.4836,116,2019-,BSRN,,,,Freely,G;B;D
-Sapporo,SAP,,Japan,43.06,141.3286,17.2,2010-2020,BSRN,,,https://epic.awi.de/id/eprint/36862/28/Sapporo.pdf,Freely,G;B;D
-Sede Boqer,SBO,,Israel,30.8597,34.7794,500,2003-2012,BSRN,,,,Freely,G;B;D
-Selegua - Mexico Solarimetric Station,SEL,,Mexico,15.7839,-91.9902,602,2017-,BSRN,Mexican Solarimetric Service,BSRN data from 2020.,https://solarimetrico.geofisica.unam.mx/,,G;B;D
+Regina,REG,,Canada,50.205,-104.713,578,1995-2011,BSRN,,,,Freely,G;B;D;IR
+Rolim de Moura,RLM,,Brazil,-11.582,-61.773,252,2007,BSRN,,Only two months of data available.,,Freely,G;B;D;IR
+Reunion Island & University,RUN,,Reunion,-20.9014,55.4836,116,2019-,BSRN,,,,Freely,G;B;D;IR
+Sapporo,SAP,,Japan,43.06,141.3286,17.2,2010-2020,BSRN,,,https://epic.awi.de/id/eprint/36862/28/Sapporo.pdf,Freely,G;B;D;IR
+Sede Boqer,SBO,,Israel,30.8597,34.7794,500,2003-2012,BSRN,,,,Freely,G;B;D;IR
+Selegua - Mexico Solarimetric Station,SEL,,Mexico,15.7839,-91.9902,602,2017-,BSRN,Mexican Solarimetric Service,BSRN data from 2020.,https://solarimetrico.geofisica.unam.mx/,,G;B;D;IR
 São Martinho da Serra,SMS,,Brazil,-29.4428,-53.8231,489,2006-,BSRN;SONDA,INPE,SONDA station (2005-2019). No maintenance between 2016-2017.,http://sonda.ccst.inpe.br/basedados/saomartinho.html,Freely,G;B;D;IR
-Sonnblick,SON,,Austria,47.054,12.9577,3108.9,2013-,BSRN;ARAD,,,https://www.sonnblick.net/en/,Freely,G;B;D
-Solar Village,SOV,,Saudi Arabia,24.91,46.41,650,1998-2003,BSRN; AERONET,NREL;KACST,,https://www.nrel.gov/grid/solar-resource/saudi-arabia.html,Freely,G;B;D
-South Pole,SPO,,Antarctica,-89.983,-24.799,2800,1992-,BSRN; ABO,NOAA,,https://gml.noaa.gov/obop/spo/,Freely,G;B;D
-Sioux Falls,SXF,South Dakota,USA,43.73403,-96.62328,473,2003-,BSRN; SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/siouxfalls.html,Freely,G;B;D
-Syowa,SYO,,Antarctica,-69.005,39.589,18,1994-,BSRN,AWI,,https://epic.awi.de/id/eprint/47515/,Freely,G;B;D
-Tamanrasset,TAM,,Algeria,22.7903,5.5292,1385,2000-,BSRN;WMO RRC,,No DIR and DIF data at TAM since 2018: Due to a broken tracker which could not yet be replaced the DIR and DIF data at Tamanrasset is missing since February 2018.,,Freely,G;B;D
+Sonnblick,SON,,Austria,47.054,12.9577,3108.9,2013-,BSRN;ARAD,,,https://www.sonnblick.net/en/,Freely,G;B;D;IR
+Solar Village,SOV,,Saudi Arabia,24.91,46.41,650,1998-2003,BSRN; AERONET,NREL;KACST,,https://www.nrel.gov/grid/solar-resource/saudi-arabia.html,Freely,G;B;D;IR
+South Pole,SPO,,Antarctica,-89.983,-24.799,2800,1992-,BSRN; ABO,NOAA,,https://gml.noaa.gov/obop/spo/,Freely,G;B;D;IR
+Sioux Falls,SXF,South Dakota,USA,43.73403,-96.62328,473,2003-,BSRN; SURFRAD,NOAA,,https://gml.noaa.gov/grad/surfrad/siouxfalls.html,Freely,G;B;D;IR
+Syowa,SYO,,Antarctica,-69.005,39.589,18,1994-,BSRN,AWI,,https://epic.awi.de/id/eprint/47515/,Freely,G;B;D;IR
+Tamanrasset,TAM,,Algeria,22.7903,5.5292,1385,2000-,BSRN;WMO RRC,,No DIR and DIF data at TAM since 2018: Due to a broken tracker which could not yet be replaced the DIR and DIF data at Tamanrasset is missing since February 2018.,,Freely,G;B;D;IR
 Tateno;Tsukuba,TAT,,Japan,36.0581,140.1258,25,1996-,BSRN;WMO RRC,JMA,,https://epic.awi.de/id/eprint/36862/27/Tateno.pdf,Freely,G;B;D;IR
-Tiksi,TIK,Siberia,Russia,71.5862,128.9188,48,2010-,BSRN,,,,Freely,G;B;D
-Tiruvallur,TIR,,India,13.0923,79.9738,36,2014-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D
-Terra Nova Bay,TNB,,Antarctica,-74.6223,164.2283,28,?,BSRN,,Candidate Station (no. 89),,Freely,G;B;D
-Toravere,TOR,,Estonia,58.254,26.462,70,1999-,BSRN,,,https://gml.noaa.gov/grad/meetings/BSRN2018_documents/2018_%20BSRN_poster_EST_Rosin.pdf,Freely,G;B;D
-Xianghe,XIA,,China,39.754,116.962,32,2005-2016,BSRN,,Station obstructed & no longer in BSRN since 2016,,Freely,G;B;D
-Yushan Station,YUS,,Taiwan,23.4876,120.9595,3858,2018-,BSRN,,,,Freely,G;B;D
+Tiksi,TIK,Siberia,Russia,71.5862,128.9188,48,2010-,BSRN,,,,Freely,G;B;D;IR
+Tiruvallur,TIR,,India,13.0923,79.9738,36,2014-,BSRN;SRRA,National Institute of wind energy,,,Freely,G;B;D;IR
+Terra Nova Bay,TNB,,Antarctica,-74.6223,164.2283,28,?,BSRN,,Candidate Station (no. 89),,Freely,G;B;D;IR
+Toravere,TOR,,Estonia,58.254,26.462,70,1999-,BSRN,,,https://gml.noaa.gov/grad/meetings/BSRN2018_documents/2018_%20BSRN_poster_EST_Rosin.pdf,Freely,G;B;D;IR
+Xianghe,XIA,,China,39.754,116.962,32,2005-2016,BSRN,,Station obstructed & no longer in BSRN since 2016,,Freely,G;B;D;IR
+Yushan Station,YUS,,Taiwan,23.4876,120.9595,3858,2018-,BSRN,,,,Freely,G;B;D;IR
 Albuquerque,ABQ,New Mexico,USA,35.03796,-106.62211,1617,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/abq.html,Freely,G;B;D
 Bismarck,BIS,North Dakota,USA,46.77179,-100.75955,503,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/bis.html,Freely,G;B;D
 Hanford,HNX,California,USA,36.31357,-119.63164,73,1995-,SOLRAD,NOAA,,https://gml.noaa.gov/grad/solrad/hnx.html,Freely,G;B;D


### PR DESCRIPTION
A reviewer pointed out that all BSRN stations are required to measured longwave irradiance, which is denoted IR in the instrumentation column. However, not all BSRN stations had this, therefore the BSRN stations that did not have this included already were modified accordingly.

The following code was used to make the modification:

```python
url = 'https://solarstations.org/_downloads/f85f41dda48ab008055bbfad91e578b2/SolarStationsOrg-station-catalog.csv'
df = pd.read_csv('solarstations.csv', dtype=str)
df.loc[df['Network'].fillna('').str.contains('BSRN') & ~df['Instrumentation'].str.contains('IR').astype(bool),
       'Instrumentation'] = 'G;B;D;IR'
df.fillna('').astype(str).to_csv('solarstations.csv', index=False)
```

It was ensured that no other components were over-written.