### PR TITLE
Add University of Lille Stations

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -745,3 +745,6 @@ Bolzano NOI Techpark,,,Italy,46.4790,11.33064,261,2020-,,University of Bozen-Bol
 Bolzano University campus,,,Italy,46.49835,11.35055,293,2017-,,University of Bozen-Bolzano,The station has also an EKO ASI-16,,Upon request,G;B;D;IR
 Sulov,,,Slovakia,49.16385,18.58569,393,2017-,,Solargis,The SPN1 was installed in August 2019,,Upon request,G;SPN1
 Bratislava,,,Slovakia,48.16983,17.07145,185,2016-2018,,Solargis,,,Upon request,G;RSP
+M'Bour,,,Senegal,14.394387,-16.958739,10,2007-2020,,University of Lille,,,,G;B;D
+Dakar,,,Senegal,14.7017,-17.4256,10,2020-,,University of Lille,,,,G;B;D
+Villeneuve d'Ascq,,,France,50.611208,3.140441,63,2008-,,University of Lille,,,,G;B;D


### PR DESCRIPTION
Add stations operated by the University of Lille.

These include M'Bour and Dakar in Senegal and Villeneuve d'Ascq (Lille) in France.