### PR TITLE
Remove Tier 3 stations from intro map

### DIFF
--- a/docs/intro.ipynb
+++ b/docs/intro.ipynb
@@ -42,6 +42,7 @@
     "esmap_stations = pd.read_csv('../esmap_stations.csv', dtype={'Tier': str}).fillna('')\n",
     "# Add esmap stations first so they are underneath\n",
     "stations = pd.concat([solarstations, esmap_stations], axis='rows', ignore_index=True)\n",
+    "stations = stations[~stations['Instrumentation'].str.contains('G;Ds')]  # remove Tier 3 stations\n",
     "\n",
     "GHIImagery = \"https://d2asdkx1wwwi7q.cloudfront.net/v20210621/ghi_global/{z}/z{z}_{x}x{y}.jpg\"\n",
     "DNIImagery = \"https://d2asdkx1wwwi7q.cloudfront.net/v20210621/dni_global/{z}/z{z}_{x}x{y}.jpg\"\n",
@@ -185,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.6"
   },
   "toc-showcode": false,
   "toc-showtags": true


### PR DESCRIPTION
There are still some Tier 3 stations in the raw files used to generate the final catalog. These stations are filtered out using this line

```python
stations = stations[~stations['Instrumentation'].str.contains('G;Ds')]  # remove Tier 3 stations
```

This wasn't being done for the map on the intro page, however.