### PR TITLE
Add contact info for QEERI stations in qatar

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -229,21 +229,21 @@ University of La Reunion Moufia,urmoufia,,Reunion,-20.90146,55.483593,96,2008-,I
 University of La Reunion Tampon,urtampon,,Reunion,-21.269277,55.50702,553,2012-2014,IOS-net,,Data can be downloaded from: https://doi.org/10.5281/zenodo.7092912,https://galilee.univ-reunion.fr/,Freely,SPN1
 University of Mauritius Reduit,uomreduit,,Mauritius,-20.24497,57.48770,200,2022-2023,IOS-net,,Data can be downloaded from: https://doi.org/10.5281/zenodo.10693484,https://galilee.univ-reunion.fr/,Freely,SPN1
 Vacoas,vacoas,,Mauritius,-20.297095,57.496918,431,2019-,IOS-net,,Data can be downloaded from: https://doi.org/10.5281/zenodo.4408662,https://galilee.univ-reunion.fr/,Freely,SPN1;UV
-HBKU-B2,B2,,Qatar,25.32,51.42,,2012-2017&2021-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Kharsaah,Kha,,Qatar,25.22,51,,2019-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Abu Samra,Abu,,Qatar,24.75,50.82,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Batna,Bat,,Qatar,25.1,51.17,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Ghuwayriyah,Ghu,,Qatar,25.84,51.27,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Jumayliyah,Jum,,Qatar,25.61,51.08,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Karaanah,Kar,,Qatar,25.01,51.04,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Shehaimiyah,She,,Qatar,25.86,50.96,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Wakrah,Wak,,Qatar,25.19,51.62,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Dukhan,Duk,,Qatar,25.41,50.76,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Turayna,Tur,,Qatar,24.74,51.21,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Khor,Kho,,Qatar,25.66,51.46,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Al Shahaniya,Sha,,Qatar,25.39,51.11,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D;UV;IR
-Ghasham Farm,Gha,,Qatar,24.85,51.27,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
-Sudanthile,Sud,,Qatar,24.63,51.06,,2020-,QEERI,QEERI,,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D;UV;IR
+HBKU-B2,B2,,Qatar,25.32,51.42,,2012-2017&2021-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Kharsaah,Kha,,Qatar,25.22,51,,2019-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Abu Samra,Abu,,Qatar,24.75,50.82,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Batna,Bat,,Qatar,25.1,51.17,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Ghuwayriyah,Ghu,,Qatar,25.84,51.27,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Jumayliyah,Jum,,Qatar,25.61,51.08,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Karaanah,Kar,,Qatar,25.01,51.04,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Shehaimiyah,She,,Qatar,25.86,50.96,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Wakrah,Wak,,Qatar,25.19,51.62,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Dukhan,Duk,,Qatar,25.41,50.76,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Turayna,Tur,,Qatar,24.74,51.21,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Khor,Kho,,Qatar,25.66,51.46,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Al Shahaniya,Sha,,Qatar,25.39,51.11,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D;UV;IR
+Ghasham Farm,Gha,,Qatar,24.85,51.27,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D
+Sudanthile,Sud,,Qatar,24.63,51.06,,2020-,QEERI,QEERI,Contact dbachour@hbku.edu.qa or dastudillo@hbku.edu.qa for more info.,https://www.hbku.edu.qa/en/qeeri/energy-center,Upon request,G;B;D;UV;IR
 Jang Bogo,JBS,,Antarctica,-74.3719,164.1344,26,2015-,,KOPRI-CNR,,,,G;B;D
 Plataforma Solar de Almeria,METAS,,Spain,37.09165,-2.36355,494,2005-,,CIEMAT,,https://www.psa.es/en/facilities/meteo/meteo.php,,G;B;D;UV;IR
 Hamm-Lippstadt University of Applied Science,HSHL,,Germany,51.682,7.843,60,2016-,,Hamm-Lippstadt University,,https://www.hshl.de/forschung-unternehmen/forschungsprojekte/meteorologische-messstation/,,G;RSI


### PR DESCRIPTION
Received the following mail:

> I was checking the station catalog and noticed that the stations from our network in Qatar link to the website of our institute, QEERI, but there is no contact information attached to the data. Is it possible to add our contact information as well, specifically [dbachour@hbku.edu.qa](mailto:dbachour@hbku.edu.qa) and [dastudillo@hbku.edu.qa](mailto:dastudillo@hbku.edu.qa), for anyone interested in learning more about the data?