### PR TITLE
Fix coordinates for Lauder station

### DIFF
--- a/solarstations.csv
+++ b/solarstations.csv
@@ -41,7 +41,7 @@ Ishigakijima,ISH,,Japan,24.3367,124.1644,5.7,2010-,BSRN,,,,Freely,G;B;D;IR
 Izaña,IZA,Tenerife,Spain,28.3093,-16.4993,2372.9,2009-,BSRN,,,,Freely,G;B;D;IR
 Kwajalein,KWA,,Marshall Islands,8.72,167.731,10,1992-2017,BSRN,,,https://gml.noaa.gov/grad/sites/kwa.html,Freely,G;B;D;IR
 Lampedusa,LMP,,Italy,35.5180,12.6300,50.0,2023-,BSRN,,,,Freely,G;B;D;IR
-Lauder,LAU,,New Zealand,-45.045,169.689,350,1999-,BSRN,,,,Freely,G;B;D;IR
+Lauder,LAU,,New Zealand,-45.03834,169.684115,350,1999-,BSRN,,,,Freely,G;B;D;IR
 Lerwick,LER,Shetland Island,United Kingdom,60.1389,-1.1847,80,2001-,BSRN,,,https://epic.awi.de/id/eprint/35071/1/Lerwick_site_info.pdf,Freely,G;B;D;IR
 Lindenberg,LIN,,Germany,52.21,14.122,125,1994-,BSRN;WMO RRC,,,https://www.dwd.de/DE/forschung/atmosphaerenbeob/lindenbergersaeule/mol/mol_node.html,Freely,G;B;D;IR
 Lulin,LLN,,Taiwan,23.4686,120.8736,2862,2009-,,,Previously a BSRN provisional stations.,http://lulin.tw/,Freely,G;B;D


### PR DESCRIPTION
Related to #353

The location of the Lauder station in the old benchmark was -45.045, 169.689, whereas the actual location is -45.03834, 169.684115 (this location was already used in the new benchmark). There is a distance of ~835 m between the two locations.